### PR TITLE
Disable node_modules caching

### DIFF
--- a/node_js.yml
+++ b/node_js.yml
@@ -4,3 +4,6 @@ node_js:
   - "node"
   - "14"
   - "12"
+
+cache:
+  npm: false


### PR DESCRIPTION
I don't believe caching provides any advantage, compared to the issues it can create. Eg. https://github.com/hapijs/eslint-plugin-hapi/pull/20#issuecomment-667401587.

FYI, this used to be disabled by default, and changed externally through an [updated default](https://docs.travis-ci.com/user/caching/#npm-cache).